### PR TITLE
Update docs to copy ca.pem to gateway

### DIFF
--- a/docs/04_Bootstrapping_Kubernetes_Security.md
+++ b/docs/04_Bootstrapping_Kubernetes_Security.md
@@ -754,6 +754,8 @@ for i in $(seq 0 2); do
       "$dir/kube-proxy.kubeconfig" \
       ubuntu@$vmname:~
 done
+
+scp "$dir/ca.pem" ubuntu@gateway:~
 ```
 
 ## Setting up local `kubeconfig`


### PR DESCRIPTION
Update to 04_Bootstrapping_Kubernetes_Security.md to include the copying of the ca.pem file to the gateway which is referenced later when configuring the LB.