### PR TITLE
Linux/amd64 updates

### DIFF
--- a/docs/00_Introduction.md
+++ b/docs/00_Introduction.md
@@ -95,7 +95,7 @@ sudo apt install -y apt-transport-https ca-certificates curl gnupg
 if [[ ! -f /etc/apt/keyrings ]];then sudo mkdir -p -m 755 /etc/apt/keyrings; fi
 curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key \
   | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-sudo chmod 644 /etc/apt/keyrings/
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' \
   | sudo tee /etc/apt/sources.list.d/kubernetes.list
 sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list

--- a/docs/00_Introduction.md
+++ b/docs/00_Introduction.md
@@ -90,12 +90,15 @@ be significantly reduced to around 8-10GB if necessary. The resulting installati
 Use this script to install all the necessary software for this guide:
 
 ```bash
-sudo apt install -y apt-transport-https ca-certificates
+sudo apt install -y apt-transport-https ca-certificates curl gnupg
 
-curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key \
+if [[ ! -f /etc/apt/keyrings ]];then sudo mkdir -p -m 755 /etc/apt/keyrings; fi
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key \
   | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' \
+sudo chmod 644 /etc/apt/keyrings/
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' \
   | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo chmod 644 /etc/apt/sources.list.d/kubernetes.list
 
 curl https://baltocdn.com/helm/signing.asc | sudo gpg --dearmor -o /usr/share/keyrings/helm.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" \

--- a/docs/01_Learning_How_to_Run_VMs_with_QEMU.md
+++ b/docs/01_Learning_How_to_Run_VMs_with_QEMU.md
@@ -426,7 +426,7 @@ requires some additional, automated preconfiguration (e.g. to set up remote SSH 
 Let's download a Noble cloud image for AMD64:
 
 ```
-wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+wget https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 ```
 
 This file is in QCOW2 format.
@@ -450,7 +450,7 @@ of VM's state from the past.
 Let's create an image backed by the Ubuntu cloud image that we have just downloaded:
 
 ```
-qemu-img create -F qcow2 -b jammy-server-cloudimg-amd64.img -f qcow2 ubuntu0.img 128G
+qemu-img create -F qcow2 -b noble-server-cloudimg-amd64.img -f qcow2 ubuntu0.img 128G
 ```
 
 > [!NOTE]
@@ -557,7 +557,7 @@ We can deal with this in two ways:
 * Reset the VM to its initial state. We can do that simply by reformatting its image file, using the same
   command that was used to create it, i.e.
   ```
-  qemu-img create -F qcow2 -b jammy-server-cloudimg-amd64.img -f qcow2 ubuntu0.img 128G
+  qemu-img create -F qcow2 -b noble-server-cloudimg-amd64.img -f qcow2 ubuntu0.img 128G
   ```
   This is where the QCOW2 format comes in handy - we effectively removed only the "diff" over the original cloud image.
 
@@ -587,7 +587,7 @@ qemu-system-x86_64 \
 After logging in, the system immediately asks for a password change:
 
 ```
-Ubuntu 22.04.3 LTS ubuntu ttyS0
+Ubuntu 24.04 LTS ubuntu ttyS0
 
 ubuntu login: ubuntu
 Password:

--- a/docs/01_Learning_How_to_Run_VMs_with_QEMU.md
+++ b/docs/01_Learning_How_to_Run_VMs_with_QEMU.md
@@ -206,28 +206,28 @@ We haven't provided any drive with an actual operating system though, so nothing
 
 After first steps with QEMU, it's time to launch an actual operating system.
 
-Let's download a Live CD image for Ubuntu Jammy:
+Let's download a Live CD image for Ubuntu Noble:
 
 ```
-wget https://cdimage.ubuntu.com/jammy/daily-live/current/jammy-desktop-amd64.iso
+wget https://releases.ubuntu.com/24.04.1/ubuntu-24.04.1-desktop-amd64.iso
 ```
 
 The QEMU option to mount it as a CDROM drive is:
 
 ```
--cdrom jammy-desktop-amd64.iso
+-cdrom ubuntu-24.04.1-desktop-amd64.iso
 ```
 
 which has a longer version:
 
 ```
--drive file=jammy-desktop-amd64.iso,index=2,media=cdrom
+-drive file=ubuntu-24.04.1-desktop-amd64.iso,index=2,media=cdrom
 ```
 
 ...which can be further split into a separate "backend" (`-blockdev`) and "frontend" (`-device`):
 
 ```
--blockdev node-name=cdrom,driver=file,read-only=on,filename=jammy-desktop-amd64.iso \
+-blockdev node-name=cdrom,driver=file,read-only=on,filename=ubuntu-24.04.1-desktop-amd64.iso \
 -device virtio-blk-pci,drive=cdrom
 ```
 
@@ -273,7 +273,7 @@ qemu-system-x86_64 \
     -mon monitor \
     -vga std \
     -bios /usr/share/qemu/OVMF.fd \
-    -cdrom jammy-desktop-amd64.iso
+    -cdrom ubuntu-24.04.1-desktop-amd64.iso
 ```
 
 When you run the machine, you'll see that UEFI has picked up the new drive and detected a system on it:
@@ -344,7 +344,7 @@ qemu-system-x86_64 \
     -mon monitor \
     -vga std \
     -bios /usr/share/qemu/OVMF.fd \
-    -cdrom jammy-desktop-amd64.iso \
+    -cdrom ubuntu-24.04.1-desktop-amd64.iso \
     -nic user
 ```
 
@@ -400,7 +400,7 @@ qemu-system-x86_64 \
     -mon monitor \
     -vga std \
     -bios /usr/share/qemu/OVMF.fd \
-    -cdrom jammy-desktop-amd64.iso \
+    -cdrom ubuntu-24.04.1-desktop-amd64.iso \
     -nic user \
     -hda ubuntu.img
 ```
@@ -423,7 +423,7 @@ in order to prepare a more server-like distribution. Here's what's going to chan
 Cloud image is a disk image with a preinstalled Ubuntu distribution. It is optimized for server usage (headless) and
 requires some additional, automated preconfiguration (e.g. to set up remote SSH access).
 
-Let's download a Jammy cloud image for AMD64:
+Let's download a Noble cloud image for AMD64:
 
 ```
 wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img

--- a/docs/02_Preparing_Environment_for_a_VM_Cluster.md
+++ b/docs/02_Preparing_Environment_for_a_VM_Cluster.md
@@ -294,7 +294,7 @@ sudo ip link add kubr0 type bridge
 sudo ip link set kubr0 up
 ```
 
-We choose **192.168.3.0/24** as the CIDR for the network, where 192.168.1.1 is the host machine address.
+We choose **192.168.3.0/24** as the CIDR for the network, where 192.168.3.1 is the host machine address.
 Let's make this a reality:
 
 ```bash

--- a/docs/02_Preparing_Environment_for_a_VM_Cluster.md
+++ b/docs/02_Preparing_Environment_for_a_VM_Cluster.md
@@ -294,11 +294,11 @@ sudo ip link add kubr0 type bridge
 sudo ip link set kubr0 up
 ```
 
-We choose **192.168.1.0/24** as the CIDR for the network, where 192.168.1.1 is the host machine address.
+We choose **192.168.3.0/24** as the CIDR for the network, where 192.168.1.1 is the host machine address.
 Let's make this a reality:
 
 ```bash
-sudo ip addr add 192.168.1.1/24 dev kubr0
+sudo ip addr add 192.168.3.1/24 dev kubr0
 ```
 
 You can inspect the effects of these commands with `ip addr show kubr0`. You should see something like this:
@@ -306,7 +306,7 @@ You can inspect the effects of these commands with `ip addr show kubr0`. You sho
 ```
 3: kubr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
     link/ether f6:a5:e7:4d:09:9a brd ff:ff:ff:ff:ff:ff
-    inet 192.168.1.1/24 scope global kubr0
+    inet 192.168.3.1/24 scope global kubr0
        valid_lft forever preferred_lft forever
 ```
 
@@ -323,7 +323,7 @@ network:
   version: 2
   bridges:
     kubr0:
-      addresses: [192.168.1.1/24]
+      addresses: [192.168.3.1/24]
 EOF
 
 sudo chmod 600 /etc/netplan/99-kubenet.yaml

--- a/docs/02_Preparing_Environment_for_a_VM_Cluster.md
+++ b/docs/02_Preparing_Environment_for_a_VM_Cluster.md
@@ -109,7 +109,7 @@ First, let's make sure we have the cloud image file in working directory. If you
 If not, download it with:
 
 ```bash
-wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+wget https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 ```
 
 Now for the actual script:
@@ -135,7 +135,7 @@ vmtype=${vmname%%[0-9]*}
 mkdir -p "$vmdir"
 
 # Prepare the VM disk image
-qemu-img create -F qcow2 -b ../jammy-server-cloudimg-amd64.img -f qcow2 "$vmdir/disk.img" 20G
+qemu-img create -F qcow2 -b ../noble-server-cloudimg-amd64.img -f qcow2 "$vmdir/disk.img" 20G
 
 # Prepare `cloud-init` config files
 cat << EOF > "$vmdir/meta-data"

--- a/docs/02_Preparing_Environment_for_a_VM_Cluster.md
+++ b/docs/02_Preparing_Environment_for_a_VM_Cluster.md
@@ -682,25 +682,25 @@ A VM that was set up from a cloud image already has an SSH server up and running
 However, by default it is configured to reject login-based attempts. We must authenticate using a public key,
 which must be preconfigured on the VM.
 
-Make sure you have an SSH key prepared on the host machine (`~/.ssh/id_rsa.pub`).
+Make sure you have an SSH key prepared on the host machine (`~/.ssh/id_ed25519.pub`).
 If not, run:
 
 ```
 ssh-keygen
 ```
 
-This will generate a keypair: a private key (`~/.ssh/id_rsa`) and a public key (`~/.ssh/id_rsa.pub`).
+This will generate a keypair: a private key (`~/.ssh/id_rsa`) and a public key (`~/.ssh/id_ed25519.pub`).
 We must now authorize this public key inside the VM by adding it to VM's `~/.ssh/authorized_keys` file.
 
 If you're already running the VM, you can do this manually: just append the contents of your
-`~/.ssh/id_rsa.pub` file to the VM's `~/.ssh/authorized_keys` file (create it if it doesn't exist).
+`~/.ssh/id_ed25519.pub` file to the VM's `~/.ssh/authorized_keys` file (create it if it doesn't exist).
 
 We'll also automate it with `cloud-init`. Edit all the `user-data` template files in `cloud-init` directory
 and replace the `password: ubuntu` line with the following entry:
 
 ```
 ssh_authorized_keys:
-  - $(<~/.ssh/id_rsa.pub)
+  - $(<~/.ssh/id_ed25519.pub)
 ```
 
 > [!NOTE]

--- a/docs/04_Bootstrapping_Kubernetes_Security.md
+++ b/docs/04_Bootstrapping_Kubernetes_Security.md
@@ -316,16 +316,16 @@ Create a `kubernetes-csr.json` file:
     "kubernetes.default.svc.cluster.local",
     "10.32.0.1",
     "kubernetes.kubenet",
-    "192.168.1.21",
+    "192.168.3.21",
     "control0",
     "control0.kubenet",
-    "192.168.1.11",
+    "192.168.3.11",
     "control1",
     "control1.kubenet",
-    "192.168.1.12",
+    "192.168.3.12",
     "control2",
     "control2.kubenet",
-    "192.168.1.13",
+    "192.168.3.13",
     "127.0.0.1"
   ]
 }
@@ -339,10 +339,10 @@ names and IPs that may be used to reach the Kubernetes API, both from outside an
   with configuration of `kube-proxy` and/or other Kubernetes components - we will see that in subsequent chapters
 * `kubernetes.kubenet` is the full domain name that resolves to the load-balanced virtual IP of the Kubernetes API
   from outside the cluster
-* 192.168.1.21 is the Kubernetes API virtual IP, which we will take care of in another chapter
+* 192.168.3.21 is the Kubernetes API virtual IP, which we will take care of in another chapter
 * the simple name `kubernetes` is resolvable both from outside and inside the cluster
 * `controlX`, `controlX.kubenet` are control node domain names
-* 192.168.1.1X are control node IPs
+* 192.168.3.1X are control node IPs
 * finally, a 127.0.0.1 entry to allow reaching Kubernetes API via localhost on control nodes
 
 Generate and sign the certificate with:
@@ -429,7 +429,7 @@ cat <<EOF > "$vmname-csr.json"
   "hosts": [
     "$vmname",
     "$vmname.kubenet",
-    "192.168.1.$((10 + $vmid))"
+    "192.168.3.$((10 + $vmid))"
   ]
 }
 EOF

--- a/docs/05_Installing_Kubernetes_Control_Plane.md
+++ b/docs/05_Installing_Kubernetes_Control_Plane.md
@@ -117,7 +117,9 @@ vmname=$(hostname -s)
 
 ### Installing `etcd`
 
-Let's download the `etcd` binary, unpack it and copy into appropriate system directory:
+Let's download the `etcd` binary, unpack it and copy into appropriate system directory.
+You might need to add `nameserver 8.8.8.8` at the end of `/etc/resolv.conf` if there are
+resolution issues below:
 
 ```bash
 etcd_archive=etcd-v${etcd_version}-linux-${arch}.tar.gz

--- a/docs/05_Installing_Kubernetes_Control_Plane.md
+++ b/docs/05_Installing_Kubernetes_Control_Plane.md
@@ -102,7 +102,8 @@ for that purpose.
 
 ### Common variables
 
-Let's define some reusable shell variables to use throughout this chapter:
+Let's define some reusable shell variables to use throughout this chapter. Run
+`ip a` to identify network device in the vmaddr line below:
 
 ```bash
 arch=amd64

--- a/docs/06_Spinning_up_Worker_Nodes.md
+++ b/docs/06_Spinning_up_Worker_Nodes.md
@@ -448,12 +448,12 @@ You should see an output like this:
 
 ```
 NAME      STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
-control0  Ready    <none>   59s   v1.28.3   192.168.1.11   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
-control1  Ready    <none>   59s   v1.28.3   192.168.1.12   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
-control2  Ready    <none>   59s   v1.28.3   192.168.1.13   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
-worker0   Ready    <none>   59s   v1.28.3   192.168.1.14   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
-worker1   Ready    <none>   59s   v1.28.3   192.168.1.15   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
-worker2   Ready    <none>   59s   v1.28.3   192.168.1.16   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+control0  Ready    <none>   59s   v1.28.3   192.168.3.11   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+control1  Ready    <none>   59s   v1.28.3   192.168.3.12   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+control2  Ready    <none>   59s   v1.28.3   192.168.3.13   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+worker0   Ready    <none>   59s   v1.28.3   192.168.3.14   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+worker1   Ready    <none>   59s   v1.28.3   192.168.3.15   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
+worker2   Ready    <none>   59s   v1.28.3   192.168.3.16   <none>        Ubuntu 22.04.3 LTS   5.15.0-83-generic   containerd://1.7.7
 ```
 
 At this point our Kubernetes deployment is starting to become functional.
@@ -559,7 +559,7 @@ We need to remedy this by adding appropriate routes on the host machine:
 
 ```bash
 for vmid in $(seq 1 6); do
-  sudo ip route add 10.${vmid}.0.0/16 via 192.168.1.$((10 + $vmid))
+  sudo ip route add 10.${vmid}.0.0/16 via 192.168.3.$((10 + $vmid))
 done
 ```
 
@@ -571,20 +571,20 @@ network:
   version: 2
   bridges:
     kubr0:
-      addresses: [192.168.1.1/24]
+      addresses: [192.168.3.1/24]
       routes:
       - to: 10.1.0.0/16
-        via: 192.168.1.1
+        via: 192.168.3.1
       - to: 10.2.0.0/16
-        via: 192.168.1.2
+        via: 192.168.3.2
       - to: 10.3.0.0/16
-        via: 192.168.1.3
+        via: 192.168.3.3
       - to: 10.4.0.0/16
-        via: 192.168.1.4
+        via: 192.168.3.4
       - to: 10.5.0.0/16
-        via: 192.168.1.5
+        via: 192.168.3.5
       - to: 10.6.0.0/16
-        via: 192.168.1.6
+        via: 192.168.3.6
 ```
 
 A better solution to this problem would be to use a CNI implementation that does not expose

--- a/docs/06_Spinning_up_Worker_Nodes.md
+++ b/docs/06_Spinning_up_Worker_Nodes.md
@@ -434,7 +434,7 @@ sudo systemctl start kubelet
 
 > [!WARNING]
 > `kubelet` by default requires that swap is turned off. This seems to be the case for Ubuntu cloud images.
-> However, just to be sure you can run `sudo swapoff` on all worker nodes.
+> However, just to be sure you can run `sudo swapoff -a` on all worker nodes.
 
 ## Scheduling a first pod
 

--- a/docs/06_Spinning_up_Worker_Nodes.md
+++ b/docs/06_Spinning_up_Worker_Nodes.md
@@ -388,6 +388,7 @@ registerWithTaints:
     value: ""
     effect: NoSchedule
 EOF
+fi
 ```
 
 > [!IMPORTANT]

--- a/docs/07_Installing_Essential_Cluster_Services.md
+++ b/docs/07_Installing_Essential_Cluster_Services.md
@@ -117,6 +117,8 @@ In the toplevel project directory (`kubenet`) on the host machine, create a dire
 
 ```bash
 mkdir nfs-pvs
+sudo chown nobody:nogroup nfs-pvs    # user:group does not matter
+sudo chmod 2770 /data/nfs            # sticky-bit on
 ```
 
 Now, let's append an entry to `/etc/exports` file to export this directory:
@@ -127,7 +129,7 @@ uid=$(stat -c '%u' "$dir")
 gid=$(stat -c '%g' "$dir")
 
 cat <<EOF | sudo tee -a /etc/exports
-$dir/nfs-pvs 192.168.3.0/24(rw,root_squash,anonuid=$uid,anongid=$gid,no_subtree_check)"
+$dir/nfs-pvs 192.168.3.0/24(rw,sync,root_squash,no_subtree_check)"
 EOF
 ```
 
@@ -139,10 +141,11 @@ EOF
 Enable NFS with:
 
 ```bash
-sudo nfsd enable
+sudo systemctl enable nfs-kernel-server.service  # if its not already
+sudo systemctl start nfs-kernel-server.service  
 ```
 
-(or use `sudo nfsd update` if `nfsd` is already enabled)
+(or use `sudo systemctl restart nfs-kernel-server.service` if `nfs-kernel-server` is already enabled)
 
 ### Installing NFS client on worker nodes
 
@@ -214,7 +217,7 @@ pvc-9de54e35-b9c2-48fa-b92a-c365ef3dff5e   8Gi        RWO            Delete     
 Finally, let's see them in the NFS exported directory:
 
 ```
-$ ls -l nfs-pvs
+$ sudo ls -l nfs-pvs
 total 0
 drwxrwxrwx  3 rjghik  staff   96 Oct 26 17:51 default-redis-data-redis-master-0-pvc-9de54e35-b9c2-48fa-b92a-c365ef3dff5e
 drwxrwxrwx  4 rjghik  staff  128 Oct 26 17:52 default-redis-data-redis-replicas-0-pvc-93c2115d-a6f7-4e59-a41b-fbef620613f3

--- a/docs/07_Installing_Essential_Cluster_Services.md
+++ b/docs/07_Installing_Essential_Cluster_Services.md
@@ -127,7 +127,7 @@ uid=$(stat -c '%u' "$dir")
 gid=$(stat -c '%g' "$dir")
 
 cat <<EOF | sudo tee -a /etc/exports
-$dir/nfs-pvs 192.168.1.0/24(rw,root_squash,anonuid=$uid,anongid=$gid,no_subtree_check)"
+$dir/nfs-pvs 192.168.3.0/24(rw,root_squash,anonuid=$uid,anongid=$gid,no_subtree_check)"
 EOF
 ```
 
@@ -168,7 +168,7 @@ Install the dynamic provisioner using `helm`:
 ```bash
 helm repo add nfs-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
 helm install -n kube-system nfs-provisioner nfs-provisioner/nfs-subdir-external-provisioner \
-  --set nfs.server=192.168.1.1 \
+  --set nfs.server=192.168.3.1 \
   --set nfs.path=$(pwd)/nfs-pvs \
   --set storageClass.defaultClass=true
 ```
@@ -261,7 +261,7 @@ metadata:
   namespace: kube-system
 spec:
   addresses:
-    - 192.168.1.30-192.168.1.254
+    - 192.168.3.30-192.168.3.254
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
@@ -274,7 +274,7 @@ spec:
 EOF
 ```
 
-Note the allocated range for Service external IPs (192.168.1.30-254). It's important for this range to be within
+Note the allocated range for Service external IPs (192.168.3.30-254). It's important for this range to be within
 the local network of the VMs, but outside the DHCP-assignable range. This is why we have previously
 [configured](02_Preparing_Environment_for_a_VM_Cluster.md#dhcp-server-configuration) it to be very narrow.
 
@@ -327,13 +327,13 @@ After a while, you should see an external IP assigned to it:
 ```bash
 $ kubectl get svc echo-lb
 NAME      TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)          AGE
-echo-lb   LoadBalancer   10.32.89.174   192.168.1.30   5678:32479/TCP   72s
+echo-lb   LoadBalancer   10.32.89.174   192.168.3.30   5678:32479/TCP   72s
 ```
 
 Try connecting to it from your host machine:
 
 ```bash
-$ curl http://192.168.1.30:5678
+$ curl http://192.168.3.30:5678
 hello-world
 ```
 


### PR DESCRIPTION
This is a superb guide! I went through the whole tutorial on a desktop running ubuntu 24.04(nougat). I've updated some sections to address issues i've encountered.

**Updates**
1. Replaced dead links to ubuntu jammy with the newer ubuntu nougat(24.04)
2.  VM network moved to 192.168.3.0/24 net to avoid classes with host and homelab network (usually in the 192.168.1.x)
3. `ssh-keygen` no longer defaults to `id_rsa.pub` now defaults to `id_ed25519.pub`
4.  Added a note to use `ip a` to identify net device (enp0s1/enp0s2..) prior to use
5.  A couple typos
6.  All k8s components updated and tested  using 192.168.3.x network
7.  fixed incomplete command `swapoff` to `swapoff -a` to turn all swap off
8.  nfsd doesn't exist on ubuntu only mac. I've replaced with nfs-kernel-server package.

**TODO**
1. i'll update all the scripts to reflect all changes above
2.  Worker/control nodes don't have dns resolution for anything external to `kubr0` network. Temp fixes were to add a secondary nameserver entry `/etc/resolv.conf`. Should be a way to integrate this with dnsmasq. I'll explore.