### PR TITLE
Prevent redownloading the ubuntu cloud image if already exists in local working directory 

### DIFF
--- a/setupall.sh
+++ b/setupall.sh
@@ -30,8 +30,13 @@ cd "$dir/auth"
 ./setuplocalkubeconfig.sh
 cd ..
 
-wget -P "$dir" -q --show-progress --https-only --timestamping -O ubuntu-cloud.img \
-  https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-${arch}.img
+image_path="$dir/ubuntu-cloud.img"
+if [[ ! -f "$image_path" ]]; then
+  wget -q --show-progress --https-only --timestamping -O "$image_path" \
+    https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-${arch}.img
+else
+  echo "Ubuntu cloud image already exists at $image_path; skipping download."
+fi
 
 "$dir/vmsetupall.sh"
 sudo -E "$dir/setuphost.sh"


### PR DESCRIPTION
The purpose of this pull request is to prevent redownloading `ubuntu-cloud.img ` if it's already exists in the local directory, because some times we are called to execute the script many times after getting some issues, we have that will to re-execute the `setupall.sh`  after fixing some local issues 



