### PR TITLE
point to supported k8s download domain

### DIFF
--- a/deploybinaries.sh
+++ b/deploybinaries.sh
@@ -13,18 +13,18 @@ cni_plugins_archive=cni-plugins-linux-${arch}-v${cni_plugins_version}.tgz
 mkdir -p "$dir/bin"
 wget -P "$dir/bin" -q --show-progress --https-only --timestamping \
   https://github.com/etcd-io/etcd/releases/download/v${etcd_version}/$etcd_archive \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler \
   https://github.com/kubernetes-sigs/cri-tools/releases/download/v${cri_version}/${crictl_archive} \
   https://github.com/opencontainers/runc/releases/download/v${runc_version}/runc.${arch} \
   https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive} \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
 
 if [[ -z $USE_CILIUM ]]; then
   wget -P "$dir/bin" -q --show-progress --https-only --timestamping \
     https://github.com/containernetworking/plugins/releases/download/v${cni_plugins_version}/${cni_plugins_archive} \
-    https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
+    https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
 fi
 
 for i in $(seq 0 2); do

--- a/docs/05_Installing_Kubernetes_Control_Plane.md
+++ b/docs/05_Installing_Kubernetes_Control_Plane.md
@@ -220,7 +220,7 @@ Download the binary and copy it to `/usr/local/bin`:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  "https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver"
+  "https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver"
 chmod +x kube-apiserver
 sudo cp kube-apiserver /usr/local/bin
 ```
@@ -639,7 +639,7 @@ Download the binary and install it in appropriate system dir:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  "https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager"
+  "https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager"
 chmod +x kube-controller-manager
 sudo cp kube-controller-manager /usr/local/bin
 ```
@@ -703,7 +703,7 @@ Download the binary and install it in appropriate system dir:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  "https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler"
+  "https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler"
 chmod +x kube-scheduler
 sudo cp kube-scheduler /usr/local/bin
 ```

--- a/docs/06_Spinning_up_Worker_Nodes.md
+++ b/docs/06_Spinning_up_Worker_Nodes.md
@@ -341,7 +341,7 @@ Download and install the `kubelet` binary:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
   
 chmod +x kubelet
 sudo cp kubelet /usr/local/bin/
@@ -644,7 +644,7 @@ Download and install the binary:
 
 ```bash
 wget -q --show-progress --https-only --timestamping \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
 
 chmod +x kube-proxy
 sudo cp kube-proxy /usr/local/bin/

--- a/setupcontrol.sh
+++ b/setupcontrol.sh
@@ -67,9 +67,9 @@ systemctl start etcd
 mkdir -p /etc/kubernetes/config
 
 wget -q --show-progress --https-only --timestamping \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-apiserver \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-controller-manager \
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-scheduler \
 
 chmod +x kube-apiserver kube-controller-manager kube-scheduler
 cp kube-apiserver kube-controller-manager kube-scheduler /usr/local/bin/

--- a/setupnode.sh
+++ b/setupnode.sh
@@ -33,7 +33,7 @@ wget -q --show-progress --https-only --timestamping \
   https://github.com/kubernetes-sigs/cri-tools/releases/download/v${cri_version}/${crictl_archive} \
   https://github.com/opencontainers/runc/releases/download/v${runc_version}/runc.${arch} \
   https://github.com/containerd/containerd/releases/download/v${containerd_version}/${containerd_archive} \
-  https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
+  https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kubelet
 
 mkdir -p \
   /opt/cni/bin \
@@ -53,7 +53,7 @@ cp containerd/bin/* /bin/
 if [[ -z $USE_CILIUM ]]; then
   wget -q --show-progress --https-only --timestamping \
     https://github.com/containernetworking/plugins/releases/download/v${cni_plugins_version}/${cni_plugins_archive} \
-    https://cdn.dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
+    https://dl.k8s.io/release/v${k8s_version}/bin/linux/${arch}/kube-proxy
 
   mkdir -p /var/lib/kube-proxy
   chmod +x kube-proxy


### PR DESCRIPTION
This pull request updates all references to the Kubernetes binary download URLs, switching from the deprecated `cdn.dl.k8s.io` domain to the current `dl.k8s.io` domain. This ensures compatibility with the latest official Kubernetes distribution channels and avoids potential issues with outdated URLs. 

Including the download page for reference: https://kubernetes.io/releases/download/

**Update download URLs for Kubernetes binaries:**

* **Bash scripts:**  
  - Updated all `wget` commands in `deploybinaries.sh`, `setupcontrol.sh`, and `setupnode.sh` to use the new `dl.k8s.io` URLs for downloading `kube-apiserver`, `kube-controller-manager`, `kube-scheduler`, `kubelet`, and `kube-proxy` binaries. [[1]](diffhunk://#diff-8bd4f7f7b3706aadacbe9ee672326458428daf94a6905510eee69f2041258eb6L16-R27) [[2]](diffhunk://#diff-e1b76373b91403400158f1a082cea42fa41125ba7f1190f8bd6c18ce90cb35efL70-R72) [[3]](diffhunk://#diff-2490bace8d560c9d18e0d80d6fadf1484d626db57b0d7cf025157bd20cf81bf8L36-R36) [[4]](diffhunk://#diff-2490bace8d560c9d18e0d80d6fadf1484d626db57b0d7cf025157bd20cf81bf8L56-R56)

* **Documentation:**  
  - Changed all example `wget` commands in `docs/05_Installing_Kubernetes_Control_Plane.md` and `docs/06_Spinning_up_Worker_Nodes.md` to use `dl.k8s.io` instead of `cdn.dl.k8s.io` for downloading Kubernetes binaries. [[1]](diffhunk://#diff-fcbe4b7ccf735c9118e3425d74344b4297a6a617dde506f51f1b4ea09defa252L223-R223) [[2]](diffhunk://#diff-fcbe4b7ccf735c9118e3425d74344b4297a6a617dde506f51f1b4ea09defa252L642-R642) [[3]](diffhunk://#diff-fcbe4b7ccf735c9118e3425d74344b4297a6a617dde506f51f1b4ea09defa252L706-R706) [[4]](diffhunk://#diff-aaa7e3d8b39cd189006a455f67b9f11e1190576bf90329b52048c494017dcfc3L344-R344) [[5]](diffhunk://#diff-aaa7e3d8b39cd189006a455f67b9f11e1190576bf90329b52048c494017dcfc3L647-R647)